### PR TITLE
Qa tests

### DIFF
--- a/Assets/Scripts/Batiments/GestionnaireBatiments.cs
+++ b/Assets/Scripts/Batiments/GestionnaireBatiments.cs
@@ -170,6 +170,22 @@ namespace Batiment
         }
 
         /// <summary>
+        /// Indique qu'il n'y a pas déjà une construction en cours, et
+        /// qu'on a les ressources nécessaires
+        /// que le bâtiment est déverrouillé, et
+        /// qu'on est en dessous de la limite max de ce bâtiment.
+        /// </summary>
+        /// <param name="batiment">Le bâtiment dont on veut savoir si on peut lancer la construction.</param>
+        /// <returns>Vrai si on pourrait lancer la construction du bâtiment.</returns>
+        public bool PeutDemarrerConstruction(BatimentEnum batiment)
+        {
+            return !ConstructionEstEnCours() &&
+                   CoutConstructionEstDisponible(batiment) &&
+                   EstDeverrouille(batiment) &&
+                   (_batiments.AccesQteBatiment(batiment) < _batiments.AccesQteMaxBatiment(batiment));
+        }
+
+        /// <summary>
         /// Démarrer une nouvelle construction.
         /// Une seul construction à la fois. Refusé si déjà au max de ce type de bâtiment.
         /// </summary>
@@ -177,12 +193,7 @@ namespace Batiment
         /// <returns>Vrai si la construction peut être démarrée</returns>
         public bool DemarrerConstruction(BatimentEnum batiment)
         {
-            // S'il y a déjà une construction en cours, ou
-            // Si le bâtiment n'est pas encore disponible, ou
-            // Si on est à la limite max, on ne commance pas la nouvelle construction
-            if (ConstructionEstEnCours() ||
-                !EstDeverrouille(batiment) ||
-                (_batiments.AccesQteBatiment(batiment) >= _batiments.AccesQteMaxBatiment(batiment)))
+            if (!PeutDemarrerConstruction(batiment))
                 return false;
 
             // On essaie d'effectuer la transaction avec l'inventaire.

--- a/Assets/Scripts/UI/BarreDeResource.cs
+++ b/Assets/Scripts/UI/BarreDeResource.cs
@@ -24,6 +24,8 @@ namespace UI
 
                 AjouterIndicateurRessource(ressource);
             }
+
+            MetAJourListeDeRessources();
         }
 
         public void MetAJourListeDeRessources()

--- a/Assets/Scripts/UI/Batiments/VueBatimentDisponible.cs
+++ b/Assets/Scripts/UI/Batiments/VueBatimentDisponible.cs
@@ -23,7 +23,7 @@ namespace UI.Batiments
         private Action MettreAJourBatimentsEnCours;
 
         private const string _aucunMaçon = "Aucun maçon";
-        private const string _ticksTexte = " ticks";
+        private const string _ticksTexte = " tick(s)";
         private const string _msgConstructionCommencé = "Construction de ";
         private const string _msgErreurConstruction = "Ne peut pas construire. Le bouton ne devrait pas être clickable";
 

--- a/Assets/Scripts/UI/Batiments/VueBatimentDisponible.cs
+++ b/Assets/Scripts/UI/Batiments/VueBatimentDisponible.cs
@@ -52,7 +52,7 @@ namespace UI.Batiments
             MetAJourCoutTicks(nbTicksConstruction);
 
             _btnDebutConstruction.interactable =
-                GestionnaireBatiments.Instance.CoutConstructionEstDisponible(_batimentEnum);
+                GestionnaireBatiments.Instance.PeutDemarrerConstruction(_batimentEnum);
         }
 
         private void MetAJourCoutTicks(long nbTicks)

--- a/Assets/Scripts/UI/Batiments/VueBatimentDisponible.cs
+++ b/Assets/Scripts/UI/Batiments/VueBatimentDisponible.cs
@@ -20,11 +20,12 @@ namespace UI.Batiments
         [SerializeField] private Button _btnDebutConstruction;
 
         private BatimentEnum _batimentEnum;
+        private Action MettreAJourBatimentsEnCours;
+
         private const string _aucunMaçon = "Aucun maçon";
-        private const string _ticksString = " ticks";
+        private const string _ticksTexte = " ticks";
         private const string _msgConstructionCommencé = "Construction de ";
         private const string _msgErreurConstruction = "Ne peut pas construire. Le bouton ne devrait pas être clickable";
-        private Action MettreAJourBatimentsEnCours;
 
         public void Init(BatimentEnum batimentEnum, Sprite icone, string nomBatiment, string coutRessources,
             string description, Action mettreAJourBatimentsEnCours)
@@ -35,15 +36,29 @@ namespace UI.Batiments
             _nomBatiment.text = nomBatiment;
             _coutRessources.text = coutRessources;
             _description.text = description;
-            UpdateValeurs();
+            MetAjourValeurs();
             _btnDebutConstruction.onClick.AddListener(DémarrerConstruction);
             MettreAJourBatimentsEnCours += mettreAJourBatimentsEnCours;
         }
-        
-        private void MetAJourCoutTicks(long nb)
+
+        public void Dispose()
         {
-            string texte = nb == -1 ? _aucunMaçon : nb + _ticksString;
-            _coutTemps.text = texte;
+            Destroy(gameObject);
+        }
+
+        public void MetAjourValeurs()
+        {
+            long nbTicksConstruction = GestionnaireProductions.Instance.NbTicksRestantsConstruction(-1, _batimentEnum);
+            MetAJourCoutTicks(nbTicksConstruction);
+
+            _btnDebutConstruction.interactable =
+                GestionnaireBatiments.Instance.CoutConstructionEstDisponible(_batimentEnum);
+        }
+
+        private void MetAJourCoutTicks(long nbTicks)
+        {
+            string nbTicksTexte = nbTicks == -1 ? _aucunMaçon : nbTicks + _ticksTexte;
+            _coutTemps.text = nbTicksTexte;
         }
 
         private void DémarrerConstruction()
@@ -57,21 +72,6 @@ namespace UI.Batiments
             {
                 Debug.LogError(_msgErreurConstruction);
             }
-            
-        }
-
-        public void Dispose()
-        {
-            Destroy(gameObject);
-        }
-
-        public void UpdateValeurs()
-        {
-            long nbTicksConstruction = GestionnaireProductions.Instance.NbTicksRestantsConstruction(-1, _batimentEnum);
-            MetAJourCoutTicks(nbTicksConstruction);
-
-            _btnDebutConstruction.interactable =
-                GestionnaireBatiments.Instance.CoutConstructionEstDisponible(_batimentEnum);
         }
     }
 }

--- a/Assets/Scripts/UI/Batiments/VueBatimentEnCours.cs
+++ b/Assets/Scripts/UI/Batiments/VueBatimentEnCours.cs
@@ -19,7 +19,7 @@ namespace UI.Batiments
         private Action MettreAJourBatiments;
 
         private const string _aucunMaçon = "Aucun maçon";
-        private const string _ticksTexte = " ticks";
+        private const string _ticksTexte = " tick(s)";
 
         private void Awake()
         {

--- a/Assets/Scripts/UI/Batiments/VueBatimentEnCours.cs
+++ b/Assets/Scripts/UI/Batiments/VueBatimentEnCours.cs
@@ -15,40 +15,40 @@ namespace UI.Batiments
         [SerializeField] private TextMeshProUGUI _nom;
         [SerializeField] private TextMeshProUGUI _completion;
         [SerializeField] private Button _boutonAnnuler;
-        private Action MettreAJourBatiments;
         
+        private Action MettreAJourBatiments;
+
+        private const string _aucunMaçon = "Aucun maçon";
+        private const string _ticksTexte = " ticks";
+
         private void Awake()
         {
             _boutonAnnuler.onClick.AddListener(AnnulerConstruction);
         }
 
-        public void Init(Sprite icone, string nom, string completion, Action mettreAJourBatiments)
+        public void Init(Sprite icone, string nom, long nbTicksRestants, Action mettreAJourBatiments)
         {
             //TODO icone
             _nom.text = nom;
-            ModifierValeurCompletion(completion);
+            MetAJourTicksRestants(nbTicksRestants);
             MettreAJourBatiments = mettreAJourBatiments;
         }
 
-        public void UpdateValeurs(string completion)
+        public void MetAJourTicksRestants(long nbTicksRestants)
         {
-            ModifierValeurCompletion(completion);
+            string nbTicksRestantsTexte = nbTicksRestants == -1 ? _aucunMaçon : nbTicksRestants + _ticksTexte;
+            _completion.text = nbTicksRestantsTexte;
         }
-
-        private void ModifierValeurCompletion(string completion)
+        
+        public void Dispose()
         {
-            _completion.text = completion + " ticks";
+            Destroy(gameObject);
         }
 
         private void AnnulerConstruction()
         {
             GestionnaireBatiments.Instance.AnnulerConstruction();
             MettreAJourBatiments?.Invoke();
-        }
-        
-        public void Dispose()
-        {
-            Destroy(gameObject);
         }
     }
 }

--- a/Assets/Scripts/UI/Batiments/VueListeBatimentsDisponibles.cs
+++ b/Assets/Scripts/UI/Batiments/VueListeBatimentsDisponibles.cs
@@ -48,7 +48,7 @@ namespace UI.Batiments
                 if (!_dictBatimentsDisponibles.ContainsKey(batiment))
                     AjouterVueBatiment(batiment);
 
-                _dictBatimentsDisponibles[batiment].UpdateValeurs();
+                _dictBatimentsDisponibles[batiment].MetAjourValeurs();
             }
         }
 

--- a/Assets/Scripts/UI/Batiments/VueListeBatimentsEnCours.cs
+++ b/Assets/Scripts/UI/Batiments/VueListeBatimentsEnCours.cs
@@ -29,17 +29,17 @@ namespace UI.Batiments
             {
                 var batiment = gestionnaireBatiments.EnConstruction;
                 long pourcentMacon = GestionnaireProfessions.Instance.AccederPourcent(ProfessionEnum.MACON);
-                long nbTicks = GestionnaireProductions.Instance.NbTicksRestantsConstruction(pourcentMacon);
+                long nbTicksRestants = GestionnaireProductions.Instance.NbTicksRestantsConstruction(pourcentMacon);
                 
                 if (_vueBatiment == null)
                 {
                     _vueBatiment = Instantiate(_vueInstancier, _content);
                     string nom = gestionnaireBatiments.BatimentConfigDict[batiment.Item1].Nom;
-                    _vueBatiment.Init(null, nom, nbTicks.ToString(), MetAJourListe);
+                    _vueBatiment.Init(null, nom, nbTicksRestants, MetAJourListe);
                 }
                 else
                 {
-                    _vueBatiment.UpdateValeurs(nbTicks.ToString());
+                    _vueBatiment.MetAJourTicksRestants(nbTicksRestants);
                 }
             }
             else


### PR DESCRIPTION
- Correction de la barre de ressource qui n'était pas à jour à l'initialisation.
- Correction du bâtiment en cours de construction pour afficher 'Aucun maçon', plutôt que '-1 ticks'.
- Correction de la condition pour désactiver le bouton de construction des bâtiments disponibles.